### PR TITLE
Add Windows stuff and fix IdentifierDecl bug

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+windows-install/gradle-2.0-bin.zip filter=lfs diff=lfs merge=lfs -text
+windows-install/jdk-8u291-windows-x64.exe

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,1 @@
+windows-install\gradle-2.0\bin\gradle deploy -x test -x joernTools

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ allprojects {
 
 task joernTools(type: Exec) {
     workingDir './python/joern-tools'
-    commandLine 'python3', 'setup.py', 'install', '--user'
+    commandLine 'python', 'setup.py', 'install', '--user'
 }
 
 // Copy extensions and plugins into Octopus plugin directory
@@ -72,5 +72,5 @@ task copyToLib2(type: Copy) {
 copyToLib2.dependsOn subprojects.build
 
 build.dependsOn subprojects.build
-//build.dependsOn joernTools
+build.dependsOn joernTools
 build.dependsOn copyToLib2

--- a/projects/extensions/jpanlib/src/main/java/ast/declarations/IdentifierDecl.java
+++ b/projects/extensions/jpanlib/src/main/java/ast/declarations/IdentifierDecl.java
@@ -10,8 +10,10 @@ public class IdentifierDecl extends ASTNode
 
 	public void addChild(ASTNode node)
 	{
-		if (node instanceof Identifier)
+		if (node instanceof Identifier && this.getName() != null)
 			setName((Identifier) node);
+		// TODO: This may need the same treatment as above.
+		// else if (node instanceof IdentifierDeclType && this.getType() != null)
 		else if (node instanceof IdentifierDeclType)
 			setType((IdentifierDeclType) node);
 
@@ -20,7 +22,7 @@ public class IdentifierDecl extends ASTNode
 
 	private void setName(Identifier name)
 	{
-		this.name = name;
+			this.name = name;
 	}
 
 	private void setType(IdentifierDeclType type)

--- a/projects/extensions/jpanlib/src/main/java/ast/declarations/IdentifierDecl.java
+++ b/projects/extensions/jpanlib/src/main/java/ast/declarations/IdentifierDecl.java
@@ -10,7 +10,7 @@ public class IdentifierDecl extends ASTNode
 
 	public void addChild(ASTNode node)
 	{
-		if (node instanceof Identifier && this.getName() != null)
+		if (node instanceof Identifier && this.getName() == null)
 			setName((Identifier) node);
 		// TODO: This may need the same treatment as above.
 		// else if (node instanceof IdentifierDeclType && this.getType() != null)

--- a/projects/octopus/build.gradle
+++ b/projects/octopus/build.gradle
@@ -47,12 +47,12 @@ dependencies{
 
 task octopusMlutils(type: Exec) {
     workingDir './python/octopus-mlutils'
-    commandLine 'python3', 'setup.py', 'install', '--user'
+    commandLine 'python', 'setup.py', 'install', '--user'
 }
 
 task octopusTools(type: Exec, dependsOn: octopusMlutils) {
     workingDir './python/octopus-tools'
-    commandLine 'python3', 'setup.py', 'install', '--user'
+    commandLine 'python', 'setup.py', 'install', '--user'
 }
 
 task copyToLib(type: Copy) {

--- a/windows-install/README.md
+++ b/windows-install/README.md
@@ -1,0 +1,1 @@
+Use `git-lfs` to get these files if you need them.

--- a/windows-install/gradle-2.0-bin.zip
+++ b/windows-install/gradle-2.0-bin.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1eb880c8755333c4d33c4351b269bebe517002532d3142c0b6164c9e8c081c3
+size 41468729

--- a/windows-install/jdk-8u291-windows-x64.exe
+++ b/windows-install/jdk-8u291-windows-x64.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9372a0abf33b38ce8afe31491af0e0b6fecb8b3705a2537709aaabd4ece7ee41
+size 176876296


### PR DESCRIPTION
There was a bug where if there's an `IdentifierDecl` with an `AssignmentExpression` where the rvalue of the assignment is an `Identifier`, the relevant `IdentifierDecl`'s identifier name was being reassigned to the rvalue ID. Fixed.